### PR TITLE
Remove JsonParams from teatime in favor of serde_json::Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teatime"
-version = "0.3.0-r1"
+version = "0.4.0"
 authors = ["John Baublitz <john.baublitz@threatstack.com>"]
 description = "Default trait implementations and data types for implementing HTTP API clients"
 repository = "https://github.com/threatstack/teatime"

--- a/src/gitlab/mod.rs
+++ b/src/gitlab/mod.rs
@@ -135,7 +135,7 @@ impl ApiClient<SimpleHttpClient> for GitlabClient {
                 json_map.insert("password".to_string(), Value::from(pass.clone()));
                 let uri = (self.base_uri.to_string() + "/oauth/token").parse::<Uri>()?;
                 let json = <Self as JsonApiClient<SimpleHttpClient>>::request_json(self, Method::Post, uri,
-                    Some(JsonParams::from(json_map)))?;
+                    Some(Value::from(json_map)))?;
                 let token_json = json.get("access_token")
                                  .ok_or(ClientError::new("Could not log in with given username and password"))?
                                  .as_str().map(|x| { x.to_string() });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use std::num;
 use std::result;
 use std::str;
 
-use serde_json::{Value,Map};
+use serde_json::Value;
 use hyper::{Client,Method,Request,Response,Uri};
 use hyper::client::{HttpConnector,FutureResponse};
 use hyper::header::Header;
@@ -179,22 +179,6 @@ impl ApiCredentials {
 
 /// Type alias for HTTPS client
 pub type HttpsClient = Client<HttpsConnector<HttpConnector>>;
-
-/// A struct to simplify JSON parameter handling for APIs that accept parameters as JSON objects
-#[derive(Debug,Clone)]
-pub struct JsonParams(Map<String, Value>);
-
-impl Display for JsonParams {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", Value::from(self.0.clone()).to_string())
-    }
-}
-
-impl From<Map<String, Value>> for JsonParams {
-    fn from(v: Map<String, Value>) -> Self {
-        JsonParams(v)
-    }
-}
 
 /// Methods defining low-level HTTP handling
 pub trait HttpClient {

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -68,7 +68,7 @@ impl ApiClient<SimpleHttpClient> for VaultClient {
         let uri = format!("{}/v1/auth/ldap/login/{}", self.api_uri, username).parse::<Uri>()?;
         let token_payload = self.request_json(
             Method::Post, uri,
-            Some(JsonParams::from(args))
+            Some(Value::from(args))
         )?;
         let token = try!(token_payload.get("auth").and_then(|x| x.get("client_token"))
                          .and_then(|x| x.as_str())


### PR DESCRIPTION
This struct previously was useful for implementing the `Display` trait for JSON but this can also be done using `serde_json::Value::from()` on a `serde_json::Map` struct for the same effect. As a result, this seems to be unnecessary code that I'm going to rip out.