### PR TITLE
Fix pagination bug with JSON arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teatime"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["John Baublitz <john.baublitz@threatstack.com>"]
 description = "Default trait implementations and data types for implementing HTTP API clients"
 repository = "https://github.com/threatstack/teatime"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A library to make implementing REST API tools easier in Rust
 
 # Documentation
-Reference and usage documentation is [here](https://docs.rs/teatime/0.4.2/teatime/).
+Reference and usage documentation is [here](https://docs.rs/teatime/0.4.3/teatime/).
 
 # Contibuting
 For contribution guidelines, please click [here](CONTRIBUTING.md)


### PR DESCRIPTION
Pagination currently nests JSON arrays when that should be a special case to join any JSON arrays that get passed back from an API.